### PR TITLE
Make basePath default to prefix

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -37,6 +37,7 @@ function SolidAuthHandler(prefix: string, authOptions: SolidAuthConfig) {
 
 export function SolidAuth(config: SolidAuthConfig) {
   const { prefix = '/api/auth', ...authOptions } = config
+  authOptions.basePath ??= prefix;
   authOptions.secret ??= process.env.AUTH_SECRET
   authOptions.trustHost ??= !!(
     process.env.AUTH_TRUST_HOST ??


### PR DESCRIPTION
I was following the [docs](https://mediakit-taupe.vercel.app/auth/install#api-route) for the API route setup, and got stuck on a problem with the configuration.

Digging a bit I saw that Auth.js defaults the basePath to `/auth` and the setup with solid-start defaults the route to `/api/auth`, being it already hardcoded through the `prefix` option.

I'm suggesting this addition since it would help the setup for newbies that like me aren't well versed on Auth.js options and the nuances with solid-start.

Maybe it would be worth to add some notes to the docs, but I don't know if it would be out of place.

If we feel the need to add to the docs is valid, ping me and I can come up with something to add in this PR.

I tested just on my project, but I believe this should be a straightforward addition, however I'm not too familiar with mediakit.
Any comments are appreciated.