### PR TITLE
trpc: rename `use*` to `create*`

### DIFF
--- a/.changeset/fuzzy-gorillas-count.md
+++ b/.changeset/fuzzy-gorillas-count.md
@@ -1,0 +1,5 @@
+---
+'@solid-mediakit/trpc': major
+---
+
+renamed all tRPC hooks from use* to create*

--- a/examples/trpc/src/routes/index.tsx
+++ b/examples/trpc/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { trpc } from '../utils/trpc'
 import { A } from '@solidjs/router'
 
 const Home: VoidComponent = () => {
-  const hello = trpc.example.hello.useQuery(() => ({ name: 'from tRPC' }))
+  const hello = trpc.example.hello.createQuery(() => ({ name: 'from tRPC' }))
   return (
     <main class='flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#026d56] to-[#152a2c]'>
       <div class='container flex flex-col items-center justify-center gap-12 px-4 py-16 '>

--- a/packages/trpc/README.md
+++ b/packages/trpc/README.md
@@ -16,7 +16,7 @@ import { A, Head, Title, Meta, Link } from 'solid-start'
 import { trpc } from '../utils/trpc'
 
 const Home: VoidComponent = () => {
-  const hello = trpc.example.hello.useQuery(() => ({ name: 'from tRPC' }))
+  const hello = trpc.example.hello.createQuery(() => ({ name: 'from tRPC' }))
   return (
     <>
       <Head>

--- a/packages/trpc/src/createTRPCSolid.ts
+++ b/packages/trpc/src/createTRPCSolid.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type TRPCClientErrorLike } from "@trpc/client";
+import { type TRPCClientErrorLike } from '@trpc/client'
 import type {
   AnyMutationProcedure,
   AnyProcedure,
@@ -9,14 +9,14 @@ import type {
   ProcedureRouterRecord,
   inferProcedureInput,
   inferProcedureOutput,
-} from "@trpc/server";
-import { type inferObservableValue } from "@trpc/server/observable";
-import { createFlatProxy } from "@trpc/server/shared";
+} from '@trpc/server'
+import { type inferObservableValue } from '@trpc/server/observable'
+import { createFlatProxy } from '@trpc/server/shared'
 import {
   type CreateSolidUtilsProxy,
   createSolidProxyDecoration,
   createSolidQueryUtilsProxy,
-} from "./shared";
+} from './shared'
 import {
   type CreateClient,
   type CreateSolidQueryHooks,
@@ -28,16 +28,16 @@ import {
   type UseTRPCQueryResult,
   type UseTRPCSubscriptionOptions,
   createHooksInternal,
-} from "./shared/hooks/createHooksInternal";
+} from './shared/hooks/createHooksInternal'
 import {
   type UseTRPCInfiniteQueryOptions,
   type UseTRPCQueryOptions,
-} from "./shared/hooks/types";
-import { type CreateTRPCSolidOptions } from "./shared/types";
+} from './shared/hooks/types'
+import { type CreateTRPCSolidOptions } from './shared/types'
 
 export type FixProcedureInput<T> = T extends void | undefined
   ? void | undefined
-  : () => T;
+  : () => T
 /**
  * @internal
  */
@@ -46,7 +46,7 @@ export type DecorateProcedure<
   TPath extends string
 > = TProcedure extends AnyQueryProcedure
   ? {
-      useQuery: <
+      createQuery: <
         TQueryFnData = inferProcedureOutput<TProcedure>,
         TData = inferProcedureOutput<TProcedure>
       >(
@@ -58,16 +58,16 @@ export type DecorateProcedure<
           TData,
           TRPCClientErrorLike<TProcedure>
         >
-      ) => UseTRPCQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+      ) => UseTRPCQueryResult<TData, TRPCClientErrorLike<TProcedure>>
     } & (inferProcedureInput<TProcedure> extends { cursor?: any }
       ? {
-          useInfiniteQuery: <
+          createInfiniteQuery: <
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             _TQueryFnData = inferProcedureOutput<TProcedure>,
             TData = inferProcedureOutput<TProcedure>
           >(
             input: FixProcedureInput<
-              Omit<inferProcedureInput<TProcedure>, "cursor">
+              Omit<inferProcedureInput<TProcedure>, 'cursor'>
             >,
             opts?: UseTRPCInfiniteQueryOptions<
               TPath,
@@ -78,13 +78,13 @@ export type DecorateProcedure<
           ) => UseTRPCInfiniteQueryResult<
             TData,
             TRPCClientErrorLike<TProcedure>
-          >;
+          >
         }
       : // eslint-disable-next-line @typescript-eslint/ban-types
         {})
   : TProcedure extends AnyMutationProcedure
   ? {
-      useMutation: <TContext = unknown>(
+      createMutation: <TContext = unknown>(
         opts?: UseTRPCMutationOptions<
           inferProcedureInput<TProcedure>,
           TRPCClientErrorLike<TProcedure>,
@@ -96,43 +96,43 @@ export type DecorateProcedure<
         TRPCClientErrorLike<TProcedure>,
         inferProcedureInput<TProcedure>,
         TContext
-      >;
+      >
     }
   : TProcedure extends AnySubscriptionProcedure
   ? {
-      useSubscription: (
+      createSubscription: (
         input: FixProcedureInput<inferProcedureInput<TProcedure>>,
         opts?: () => UseTRPCSubscriptionOptions<
           inferObservableValue<inferProcedureOutput<TProcedure>>,
           TRPCClientErrorLike<TProcedure>
         >
-      ) => void;
+      ) => void
     }
-  : never;
+  : never
 
 /**
  * @internal
  */
 export type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
-  TPath extends string = ""
+  TPath extends string = ''
 > = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
-        TProcedures[TKey]["_def"]["record"],
+        TProcedures[TKey]['_def']['record'],
         `${TPath}${TKey & string}.`
       >
     : TProcedures[TKey] extends AnyProcedure
     ? DecorateProcedure<TProcedures[TKey], `${TPath}${TKey & string}`>
-    : never;
-};
+    : never
+}
 
 export type CreateTRPCSolidStart<TRouter extends AnyRouter> = {
-  useContext(): CreateSolidUtilsProxy<TRouter>;
-  Provider: TRPCProvider<TRouter>;
-  createClient: CreateClient<TRouter>;
-  useDehydratedState: UseDehydratedState<TRouter>;
-} & DecoratedProcedureRecord<TRouter["_def"]["record"]>;
+  useContext(): CreateSolidUtilsProxy<TRouter>
+  Provider: TRPCProvider<TRouter>
+  createClient: CreateClient<TRouter>
+  useDehydratedState: UseDehydratedState<TRouter>
+} & DecoratedProcedureRecord<TRouter['_def']['record']>
 
 /**
  * @internal
@@ -140,30 +140,30 @@ export type CreateTRPCSolidStart<TRouter extends AnyRouter> = {
 export function createHooksInternalProxy<TRouter extends AnyRouter>(
   trpc: CreateSolidQueryHooks<TRouter>
 ) {
-  type CreateHooksInternalProxy = CreateTRPCSolidStart<TRouter>;
+  type CreateHooksInternalProxy = CreateTRPCSolidStart<TRouter>
 
   return createFlatProxy<CreateHooksInternalProxy>((key) => {
-    if (key === "useContext") {
+    if (key === 'useContext') {
       return () => {
-        const context = trpc.useContext();
+        const context = trpc.useContext()
         // create a stable reference of the utils context
-        return (createSolidQueryUtilsProxy as any)(context as any);
-      };
+        return (createSolidQueryUtilsProxy as any)(context as any)
+      }
     }
 
     if ((key as string) in trpc) {
-      return (trpc as any)[key];
+      return (trpc as any)[key]
     }
 
-    return createSolidProxyDecoration(key as string, trpc);
-  });
+    return createSolidProxyDecoration(key as string, trpc)
+  })
 }
 
 export function createTRPCSolidStart<TRouter extends AnyRouter>(
   opts?: CreateTRPCSolidOptions<TRouter>
 ) {
-  const hooks = createHooksInternal<TRouter>(opts);
-  const proxy = createHooksInternalProxy<TRouter>(hooks);
+  const hooks = createHooksInternal<TRouter>(opts)
+  const proxy = createHooksInternalProxy<TRouter>(hooks)
 
-  return proxy;
+  return proxy
 }

--- a/packages/trpc/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/trpc/src/shared/hooks/createHooksInternal.tsx
@@ -6,9 +6,9 @@ import {
   type CreateMutationOptions,
   type CreateMutationResult,
   type CreateQueryResult,
-  createInfiniteQuery as __useInfiniteQuery,
-  createMutation as __useMutation,
-  createQuery as __useQuery,
+  createInfiniteQuery as __createInfiniteQuery,
+  createMutation as __createMutation,
+  createQuery as __createQuery,
   type QueryClientProviderProps,
   type QueryClient,
   InfiniteData,
@@ -308,7 +308,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
     return __useContext(Context)
   }
 
-  function useQuery<
+  function createQuery<
     TPath extends keyof TQueryValues & string,
     TQueryFnData = TQueryValues[TPath]['output'],
     TData = TQueryValues[TPath]['output']
@@ -330,7 +330,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
       mergeProps(opts?.() ?? {}, {
         context: SolidQueryContext,
       })
-    return __useQuery(() => ({
+    return __createQuery(() => ({
       queryKey: getArrayQueryKey(pathAndInput()),
       queryFn: wrapFn(() => {
         return (createTRPCClient(config?.config(event) as any) as any).query(
@@ -341,7 +341,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
     })) as UseTRPCQueryResult<TData, TError>
   }
 
-  function useMutation<
+  function createMutation<
     TPath extends keyof TMutationValues & string,
     TContext = unknown
   >(
@@ -363,7 +363,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
       mergeProps(opts?.(), {
         context: SolidQueryContext,
       })
-    return __useMutation(() => ({
+    return __createMutation(() => ({
       mutationFn: (input) => {
         const actualPath = Array.isArray(path) ? path[0] : path
 
@@ -386,7 +386,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
    *  **Experimental.** API might change without major version bump
    * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠
    */
-  function useSubscription<
+  function createSubscription<
     TPath extends keyof TSubscriptions & string,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>
   >(
@@ -441,7 +441,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
     )
   }
 
-  function useInfiniteQuery<TPath extends TInfiniteQueryNames & string>(
+  function createInfiniteQuery<TPath extends TInfiniteQueryNames & string>(
     pathAndInput: () => [
       path: TPath,
       input: Omit<TQueryValues[TPath]['input'], 'cursor'>
@@ -458,7 +458,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
       mergeProps(opts?.(), {
         context: SolidQueryContext,
       })
-    return __useInfiniteQuery(() => ({
+    return __createInfiniteQuery(() => ({
       queryKey: getArrayQueryKey(pathAndInput()),
       queryFn: (queryFunctionContext) => {
         const actualInput = {
@@ -476,10 +476,10 @@ export function createHooksInternal<TRouter extends AnyRouter>(
   return {
     Provider: TRPCProvider,
     useContext,
-    useQuery,
-    useMutation,
-    useSubscription,
-    useInfiniteQuery,
+    createQuery,
+    createMutation,
+    createSubscription,
+    createInfiniteQuery,
   }
 }
 

--- a/packages/trpc/src/shared/proxy/decorationProxy.ts
+++ b/packages/trpc/src/shared/proxy/decorationProxy.ts
@@ -23,7 +23,7 @@ export function createSolidProxyDecoration<TRouter extends AnyRouter>(
 
     // The `path` ends up being something like `post.byId`
     const path = pathCopy.join(".");
-    if (lastArg === "useMutation") {
+    if (lastArg === "createMutation") {
       return (hooks as any)[lastArg](path, ...args);
     }
     return (hooks as any)[lastArg](

--- a/packages/trpc/src/shared/types.ts
+++ b/packages/trpc/src/shared/types.ts
@@ -26,7 +26,7 @@ export interface CreateTRPCSolidOptions<TRouter extends AnyRouter> {
    * Override behaviors of the built-in hooks
    */
   unstable_overrides?: {
-    useMutation?: Partial<UseMutationOverride>
+    createMutation?: Partial<UseMutationOverride>
   }
 
   /**


### PR DESCRIPTION
This PR is majorly breaking!

I have renamed all tRPC hooks from `use*` to `create*`.

Personally, I think this fits better with Solid's naming conventions and was a point of confusion when I first used the library as I came from `@tanstack/solid-query` which uses the `create*` naming convention.

Ryan discussed how he views Solid's naming convention [here](https://github.com/solidjs/solid/issues/317#issuecomment-767715235) as well and I think based on it `create*` seems like a better move.