### PR TITLE
expose `UseTRPCQueryResult`

### DIFF
--- a/.changeset/loud-moles-attend.md
+++ b/.changeset/loud-moles-attend.md
@@ -1,5 +1,5 @@
 ---
-'@solid-mediakit/trpc': minor
+'@solid-mediakit/trpc': patch
 ---
 
 expose `UseTRPCQueryResult`

--- a/.changeset/loud-moles-attend.md
+++ b/.changeset/loud-moles-attend.md
@@ -1,0 +1,5 @@
+---
+'@solid-mediakit/trpc': minor
+---
+
+expose `UseTRPCQueryResult`

--- a/packages/trpc/src/index.tsx
+++ b/packages/trpc/src/index.tsx
@@ -14,3 +14,4 @@ export {
   type CreateTRPCSolidStart,
 } from './createTRPCSolid'
 export { createSolidQueryHooks } from './interop'
+export { UseTRPCQueryResult } from "./shared";


### PR DESCRIPTION
It's useful to be able to define a function which can take in the query result including the tRPC extras such as `path`.

Eg.
```ts
function createSomeQueryAbstraction(query: UseTRPCQueryResult) {
   // ...
}

const query = trpc.some.query.useQuery();
createSomeQueryAbstraction(query);
```