### PR TITLE
Implement `query.path` and `query.queryKey`

### DIFF
--- a/.changeset/tasty-bikes-exist.md
+++ b/.changeset/tasty-bikes-exist.md
@@ -1,0 +1,5 @@
+---
+'@solid-mediakit/trpc': patch
+---
+
+implement `query.path` and `query.queryKey`


### PR DESCRIPTION
Usage:
```ts
const query = trpc.some.query.createQuery();

query.trpc.path;
query.trpc.queryKey;
```

Be aware `query.trpc.path` previously had a type definition but it lacked an implementation which would definitely have been a bug.