### PR TITLE
Fix parsing of args to tRPC vanilla client for mutations

### DIFF
--- a/.changeset/four-pumpkins-retire.md
+++ b/.changeset/four-pumpkins-retire.md
@@ -1,0 +1,5 @@
+---
+'@solid-mediakit/trpc': patch
+---
+
+fix `trpc.context` for `createMutation`

--- a/packages/trpc/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/trpc/src/shared/hooks/createHooksInternal.tsx
@@ -366,7 +366,7 @@ export function createHooksInternal<TRouter extends AnyRouter>(
 
         return ctx
           .client()
-          .mutation(...getClientArgs([actualPath, input], opts))
+          .mutation(...getClientArgs([actualPath, input], opts?.()))
       },
       ...withCtxOpts(),
     })) as UseTRPCMutationResult<


### PR DESCRIPTION
The following does not currently work:
```ts
trpc.some.query.createMutation(() => ({
   trpc: {
       context: { a: true }
   }
}));
```

`trpc.context` can be accessed within tRPC links and currently it is not correctly set for mutations.

This PR should fix it by correctly calling the opts function before parsing it to the tRPC Vanilla client.