### PR TITLE
Switch to `rimraf` for `rm -rf` and migrate to turbo v2

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "clean": "rm -rf ./node_modules .turbo .astro .vercel",
+    "clean": "rimraf ./node_modules .turbo .astro .vercel",
     "ts:check": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "turbo run build --filter=./packages/**/*",
     "dev": "turbo run dev --parallel --include-dependencies --no-deps",
-    "clean": "turbo run clean --parallel && rm -rf node_modules pnpm-lock.yaml && pnpm install",
+    "clean": "turbo run clean --parallel && rimraf node_modules pnpm-lock.yaml && pnpm install",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",
@@ -33,6 +33,7 @@
     "eslint-plugin-n": "^15.5.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.8.0",
+    "rimraf": "^5.0.7",
     "rollup": "^4.9.6",
     "sort-package-json": "^2.1.0",
     "tslib": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.2",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",
@@ -31,13 +33,12 @@
     "eslint-plugin-n": "^15.5.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.8.0",
-    "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-node-resolve": "^15.2.3",
     "rollup": "^4.9.6",
     "sort-package-json": "^2.1.0",
     "tslib": "^2.5.0",
-    "turbo": "1.2.4",
+    "turbo": "2.0.4",
     "typescript": "^4.8.2",
     "vite": "^5.1.6"
-  }
+  },
+  "packageManager": "pnpm@9.3.0"
 }

--- a/packages/auth/solid/package.json
+++ b/packages/auth/solid/package.json
@@ -4,9 +4,9 @@
   "version": "2.0.11",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && rollup -c && node scripts/postbuild",
-    "clean": "pnpm clean:dist && rm -rf ./node_modules .turbo .solid",
+    "clean": "pnpm clean:dist && rimraf ./node_modules .turbo .solid",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
-    "clean:dist": "rm -rf dist compiler client.* index.* types.* utils.*",
+    "clean:dist": "rimraf dist compiler client.* index.* types.* utils.*",
     "typecheck": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/auth/solid/package.json
+++ b/packages/auth/solid/package.json
@@ -6,7 +6,7 @@
     "build": "tsc -p tsconfig.build.json && rollup -c && node scripts/postbuild",
     "clean": "pnpm clean:dist && rimraf ./node_modules .turbo .solid",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
-    "clean:dist": "rimraf dist compiler client.* index.* types.* utils.*",
+    "clean:dist": "rimraf -g dist compiler client.* index.* types.* utils.*",
     "typecheck": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc && rollup -c",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rimraf dist node_modules"
   },
   "license": "ISC",
   "devDependencies": {

--- a/packages/og/package.json
+++ b/packages/og/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc && tsup",
     "test": "vitest --globals",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rimraf dist node_modules"
   },
   "keywords": [
     "MediaKit",

--- a/packages/prpc/solid/package.json
+++ b/packages/prpc/solid/package.json
@@ -4,9 +4,9 @@
   "version": "1.2.3",
   "scripts": {
     "build": "rimraf dist && tsup --config ./tsup.config.js",
-    "clean": "pnpm clean:dist && rm -rf ./node_modules .turbo .solid",
+    "clean": "pnpm clean:dist && rimraf ./node_modules .turbo .solid",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
-    "clean:dist": "rm -rf dist",
+    "clean:dist": "rimraf dist",
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
@@ -40,7 +40,6 @@
     "@tanstack/solid-query": "^5.29.3",
     "@types/node": "^18.7.14",
     "@typescript-eslint/parser": "^5.44.0",
-    "rimraf": "^5.0.7",
     "solid-js": "^1.8.15",
     "tsup": "^6.5.0",
     "tsup-preset-solid": "0.1.8",

--- a/packages/prpc/solid/package.json
+++ b/packages/prpc/solid/package.json
@@ -3,7 +3,7 @@
   "description": "A typesafed Wrapper for Solid's RPC protocol",
   "version": "1.2.3",
   "scripts": {
-    "build": "rm -rf dist && tsup --config ./tsup.config.js",
+    "build": "rimraf dist && tsup --config ./tsup.config.js",
     "clean": "pnpm clean:dist && rm -rf ./node_modules .turbo .solid",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
     "clean:dist": "rm -rf dist",
@@ -40,12 +40,13 @@
     "@tanstack/solid-query": "^5.29.3",
     "@types/node": "^18.7.14",
     "@typescript-eslint/parser": "^5.44.0",
+    "rimraf": "^5.0.7",
     "solid-js": "^1.8.15",
+    "tsup": "^6.5.0",
+    "tsup-preset-solid": "0.1.8",
     "typescript": "^4.8.2",
     "vinxi": "^0.3.10",
-    "zod": "^3.22.4",
-    "tsup": "^6.5.0",
-    "tsup-preset-solid": "0.1.8"
+    "zod": "^3.22.4"
   },
   "dependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc && rollup -c",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rimraf dist node_modules"
   },
   "license": "ISC",
   "devDependencies": {

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.3",
   "scripts": {
     "build": "tsc -p . && rollup -c && node scripts/postbuild.mjs",
-    "clean": "pnpm rm -rf ./node_modules .turbo .solid handler.*",
+    "clean": "pnpm rimraf ./node_modules .turbo .solid handler.*",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.3",
   "scripts": {
     "build": "tsc -p . && rollup -c && node scripts/postbuild.mjs",
-    "clean": "pnpm rimraf ./node_modules .turbo .solid handler.*",
+    "clean": "rimraf -g ./node_modules .turbo .solid handler.*",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       turbo:
-        specifier: 1.2.4
-        version: 1.2.4
+        specifier: 2.0.4
+        version: 2.0.4
       typescript:
         specifier: ^4.8.2
         version: 4.9.5
@@ -648,10 +648,10 @@ importers:
     dependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@3.29.4)(tslib@2.6.2)(typescript@4.9.5)
+        version: 11.1.6(rollup@4.13.0)(tslib@2.6.2)(typescript@4.9.5)
       '@rollup/pluginutils':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@3.29.4)
+        version: 5.0.2(rollup@4.13.0)
     devDependencies:
       '@solidjs/meta':
         specifier: ^0.29.3
@@ -661,7 +661,7 @@ importers:
         version: 0.13.1(solid-js@1.8.15)
       '@solidjs/start':
         specifier: ^1.0.0-rc.0
-        version: 1.0.0-rc.0(rollup@3.29.4)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
+        version: 1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
       '@tanstack/solid-query':
         specifier: ^5.29.3
         version: 5.29.3(solid-js@1.8.15)
@@ -671,6 +671,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.44.0
         version: 5.52.0(eslint@8.57.0)(typescript@4.9.5)
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
       solid-js:
         specifier: ^1.8.15
         version: 1.8.15
@@ -679,7 +682,7 @@ importers:
         version: 6.5.0(postcss@8.4.38)(typescript@4.9.5)
       tsup-preset-solid:
         specifier: 0.1.8
-        version: 0.1.8(esbuild@0.21.5)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5))
+        version: 0.1.8(esbuild@0.15.18)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5))
       typescript:
         specifier: ^4.8.2
         version: 4.9.5
@@ -4851,6 +4854,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -6485,6 +6489,12 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.7:
+    resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
+    engines: {node: '>=14.18'}
     hasBin: true
 
   rollup-plugin-visualizer@5.12.0:
@@ -7072,68 +7082,38 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
-  turbo-darwin-64@1.2.4:
-    resolution: {integrity: sha512-fIseb9faJZdrJ2LXJAMZmSI5hV5MbHiRKIEnwt6pqk9+8HcJnsz3Rfo7uSNH07Qo64moXyoDHa0YFj00PH2Aeg==}
+  turbo-darwin-64@2.0.4:
+    resolution: {integrity: sha512-x9mvmh4wudBstML8Z8IOmokLWglIhSfhQwnh2gBCSqabgVBKYvzl8Y+i+UCNPxheCGTgtsPepTcIaKBIyFIcvw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.2.4:
-    resolution: {integrity: sha512-/iAKexDsoXLHeLpM71+MMHDL7x95++M1GSIVkME1MJyUwG0RMfjlciBG99ZCBlya39rJhc0ifSLhZVWUttTmJA==}
+  turbo-darwin-arm64@2.0.4:
+    resolution: {integrity: sha512-/B1Ih8zPRGVw5vw4SlclOf3C/woJ/2T6ieH6u54KT4wypoaVyaiyMqBcziIXycdObIYr7jQ+raHO7q3mhay9/A==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-freebsd-64@1.2.4:
-    resolution: {integrity: sha512-YULjq/JW8e2ax/McguL+yHmZxGdLXseKVIVWP1f2dhuF9ztAbGTaagdDnQ8atsqDO0gFsb3WiRo4+4X/NAbgvQ==}
-    cpu: [x64]
-    os: [freebsd]
-
-  turbo-freebsd-arm64@1.2.4:
-    resolution: {integrity: sha512-GCi7soURYBOu7TOEeqAcShKzaOxuN0w60+2BejCKWYe2VtzRvM8ACGTNXRcle/r/9JICiyw3LpxvieJpqdSnOw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  turbo-linux-32@1.2.4:
-    resolution: {integrity: sha512-9+Yyig9JWkDgLT7Y4L9LPH4ik0Tlb3E2ac2fJFI4shMp2ETcV1ehyjDXT/LzLTSkf4mGLsww+WYKtzXJNVThRg==}
-    cpu: [ia32]
-    os: [linux]
-
-  turbo-linux-64@1.2.4:
-    resolution: {integrity: sha512-MDnDrfWrtK4BOWh2+a3nrkFacjtEy7sUZnnIhTqUM5FOKD8ISh8VTS3C16hi2BfAjCnZhqIrynbNH/P1YH6j3Q==}
+  turbo-linux-64@2.0.4:
+    resolution: {integrity: sha512-6aG670e5zOWu6RczEYcB81nEl8EhiGJEvWhUrnAfNEUIMBEH1pR5SsMmG2ol5/m3PgiRM12r13dSqTxCLcHrVg==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.2.4:
-    resolution: {integrity: sha512-gs3mhARtzNBoEQn6S05mefYrmcKtWJexwnDQiQZ8fXIkAE9IqvIWNk7S+MyixQH/11jwUqFPtRsn1yQWbvZDhQ==}
+  turbo-linux-arm64@2.0.4:
+    resolution: {integrity: sha512-AXfVOjst+mCtPDFT4tCu08Qrfv12Nj7NDd33AjGwV79NYN1Y1rcFY59UQ4nO3ij3rbcvV71Xc+TZJ4csEvRCSg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-linux-arm@1.2.4:
-    resolution: {integrity: sha512-Vx2YIFhNqgz4L3Z7zKauPmhgA4QzEtUsjekN0HeEpkZkhWONbcF2gc2j9LTNzicLbI+RoiKrwJWt9qkydqU6mg==}
-    cpu: [arm]
-    os: [linux]
-
-  turbo-linux-mips64le@1.2.4:
-    resolution: {integrity: sha512-99k9FbOJBbIjhoUOE4uOioh65kZI0VHZzf3JlhpYo3j9r+KGhu7aYTbbvd7j1qQ9o5vToic5vc3OkOm2LKgvig==}
-    cpu: [mips64el]
-    os: [linux]
-
-  turbo-linux-ppc64le@1.2.4:
-    resolution: {integrity: sha512-M+/sBWQ4UXVplSt5/pIvIRBT6NfEOVFvcOpbzWNjAhLE0vE/ZYeU07S/HjRZd6PMiodT61UyC7BwDQOa2pDOQg==}
-    cpu: [ppc64]
-    os: [linux]
-
-  turbo-windows-32@1.2.4:
-    resolution: {integrity: sha512-Y2R5ZmOHOTgr/pAQAVY39BpRDMRCjyaeLxwIAIkvyNSBpkU/TtnJZXMlt2so42Qv9Jren1mlvxm+g1nb0zAQQg==}
-    cpu: [ia32]
-    os: [win32]
-
-  turbo-windows-64@1.2.4:
-    resolution: {integrity: sha512-F8tapVNGeWXdNSFJDybOSNWxmi6xF59oZIP7+c043D/IBvkIGTQG449QD9EdUtSq8pe20zM95VKmW9mUjqHYPQ==}
+  turbo-windows-64@2.0.4:
+    resolution: {integrity: sha512-QOnUR9hKl0T5gq5h1fAhVEqBSjpcBi/BbaO71YGQNgsr6pAnCQdbG8/r3MYXet53efM0KTdOhieWeO3KLNKybA==}
     cpu: [x64]
     os: [win32]
 
-  turbo@1.2.4:
-    resolution: {integrity: sha512-3MPu+uvaKvmW5R0JncX8TJRli/5Z5Mz/H260oCfmGlEuVdvdn7Gf6ZefDnYiuDe5ofltq78SL0LTIAqLYbUmiw==}
+  turbo-windows-arm64@2.0.4:
+    resolution: {integrity: sha512-3v8WpdZy1AxZw0gha0q3caZmm+0gveBQ40OspD6mxDBIS+oBtO5CkxhIXkFJJW+jDKmDlM7wXDIGfMEq+QyNCQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.0.4:
+    resolution: {integrity: sha512-Ilme/2Q5kYw0AeRr+aw3s02+WrEYaY7U8vPnqSZU/jaDG/qd6jHVN6nRWyd/9KXvJGYM69vE6JImoGoyNjLwaw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -9833,13 +9813,13 @@ snapshots:
       rollup: 4.9.6
       tslib: 2.6.2
 
-  '@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.6.2)(typescript@4.9.5)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.13.0)(tslib@2.6.2)(typescript@4.9.5)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
       resolve: 1.22.8
       typescript: 4.9.5
     optionalDependencies:
-      rollup: 3.29.4
+      rollup: 4.13.0
       tslib: 2.6.2
 
   '@rollup/pluginutils@4.2.1':
@@ -9854,6 +9834,14 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 3.29.4
+
+  '@rollup/pluginutils@5.0.2(rollup@4.13.0)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.13.0
 
   '@rollup/pluginutils@5.1.0(rollup@3.29.4)':
     dependencies:
@@ -9982,32 +9970,6 @@ snapshots:
     dependencies:
       solid-js: 1.8.17
 
-  '@solidjs/start@1.0.0-rc.0(rollup@3.29.4)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))':
-    dependencies:
-      '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      '@vinxi/server-components': 0.3.3(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      '@vinxi/server-functions': 0.3.2(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      defu: 6.1.4
-      error-stack-parser: 2.1.4
-      glob: 10.3.10
-      html-to-image: 1.11.11
-      radix3: 1.1.1
-      seroval: 1.0.4
-      seroval-plugins: 1.0.4(seroval@1.0.4)
-      shikiji: 0.9.19
-      source-map-js: 1.0.2
-      terracotta: 1.0.5(solid-js@1.8.15)
-      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
-      vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - rollup
-      - solid-js
-      - supports-color
-      - vinxi
-      - vite
-
   '@solidjs/start@1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))':
     dependencies:
       '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
@@ -10025,6 +9987,32 @@ snapshots:
       terracotta: 1.0.5(solid-js@1.8.15)
       vite-plugin-inspect: 0.7.42(rollup@4.13.0)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))
       vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@testing-library/jest-dom'
+      - rollup
+      - solid-js
+      - supports-color
+      - vinxi
+      - vite
+
+  '@solidjs/start@1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      '@vinxi/server-components': 0.3.3(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      '@vinxi/server-functions': 0.3.2(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      defu: 6.1.4
+      error-stack-parser: 2.1.4
+      glob: 10.3.10
+      html-to-image: 1.11.11
+      radix3: 1.1.1
+      seroval: 1.0.4
+      seroval-plugins: 1.0.4(seroval@1.0.4)
+      shikiji: 0.9.19
+      source-map-js: 1.0.2
+      terracotta: 1.0.5(solid-js@1.8.15)
+      vite-plugin-inspect: 0.7.42(rollup@4.13.0)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
+      vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@testing-library/jest-dom'
@@ -11837,12 +11825,12 @@ snapshots:
   esbuild-openbsd-64@0.15.18:
     optional: true
 
-  esbuild-plugin-solid@0.5.0(esbuild@0.21.5)(solid-js@1.8.15):
+  esbuild-plugin-solid@0.5.0(esbuild@0.15.18)(solid-js@1.8.15):
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-typescript': 7.23.3(@babel/core@7.20.12)
       babel-preset-solid: 1.8.16(@babel/core@7.20.12)
-      esbuild: 0.21.5
+      esbuild: 0.15.18
       solid-js: 1.8.15
     transitivePeerDependencies:
       - supports-color
@@ -14658,6 +14646,10 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rimraf@5.0.7:
+    dependencies:
+      glob: 10.3.10
+
   rollup-plugin-visualizer@5.12.0(rollup@4.13.0):
     dependencies:
       open: 8.4.2
@@ -15363,9 +15355,9 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup-preset-solid@0.1.8(esbuild@0.21.5)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5)):
+  tsup-preset-solid@0.1.8(esbuild@0.15.18)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5)):
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.21.5)(solid-js@1.8.15)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.15.18)(solid-js@1.8.15)
       tsup: 6.5.0(postcss@8.4.38)(typescript@4.9.5)
       type-fest: 3.13.1
     transitivePeerDependencies:
@@ -15434,56 +15426,32 @@ snapshots:
       wcwidth: 1.0.1
       yargs: 17.7.2
 
-  turbo-darwin-64@1.2.4:
+  turbo-darwin-64@2.0.4:
     optional: true
 
-  turbo-darwin-arm64@1.2.4:
+  turbo-darwin-arm64@2.0.4:
     optional: true
 
-  turbo-freebsd-64@1.2.4:
+  turbo-linux-64@2.0.4:
     optional: true
 
-  turbo-freebsd-arm64@1.2.4:
+  turbo-linux-arm64@2.0.4:
     optional: true
 
-  turbo-linux-32@1.2.4:
+  turbo-windows-64@2.0.4:
     optional: true
 
-  turbo-linux-64@1.2.4:
+  turbo-windows-arm64@2.0.4:
     optional: true
 
-  turbo-linux-arm64@1.2.4:
-    optional: true
-
-  turbo-linux-arm@1.2.4:
-    optional: true
-
-  turbo-linux-mips64le@1.2.4:
-    optional: true
-
-  turbo-linux-ppc64le@1.2.4:
-    optional: true
-
-  turbo-windows-32@1.2.4:
-    optional: true
-
-  turbo-windows-64@1.2.4:
-    optional: true
-
-  turbo@1.2.4:
+  turbo@2.0.4:
     optionalDependencies:
-      turbo-darwin-64: 1.2.4
-      turbo-darwin-arm64: 1.2.4
-      turbo-freebsd-64: 1.2.4
-      turbo-freebsd-arm64: 1.2.4
-      turbo-linux-32: 1.2.4
-      turbo-linux-64: 1.2.4
-      turbo-linux-arm: 1.2.4
-      turbo-linux-arm64: 1.2.4
-      turbo-linux-mips64le: 1.2.4
-      turbo-linux-ppc64le: 1.2.4
-      turbo-windows-32: 1.2.4
-      turbo-windows-64: 1.2.4
+      turbo-darwin-64: 2.0.4
+      turbo-darwin-arm64: 2.0.4
+      turbo-linux-64: 2.0.4
+      turbo-linux-arm64: 2.0.4
+      turbo-windows-64: 2.0.4
+      turbo-windows-arm64: 2.0.4
 
   type-check@0.4.0:
     dependencies:
@@ -16019,21 +15987,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.7.42(rollup@3.29.4)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1)):
-    dependencies:
-      '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      debug: 4.3.4
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 5.3.1(@types/node@18.17.5)(terser@5.27.1)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   vite-plugin-inspect@0.7.42(rollup@4.13.0)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1)):
     dependencies:
       '@antfu/utils': 0.7.7
@@ -16060,6 +16013,21 @@ snapshots:
       picocolors: 1.0.0
       sirv: 2.0.4
       vite: 5.1.6(@types/node@20.11.26)(terser@5.27.1)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.7.42(rollup@4.13.0)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1)):
+    dependencies:
+      '@antfu/utils': 0.7.7
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
+      debug: 4.3.4
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.3.1(@types/node@18.17.5)(terser@5.27.1)
     transitivePeerDependencies:
       - rollup
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       prettier:
         specifier: ^2.8.0
         version: 2.8.0
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
       rollup:
         specifier: ^4.9.6
         version: 4.9.6
@@ -648,10 +651,10 @@ importers:
     dependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.13.0)(tslib@2.6.2)(typescript@4.9.5)
+        version: 11.1.6(rollup@3.29.4)(tslib@2.6.2)(typescript@4.9.5)
       '@rollup/pluginutils':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@4.13.0)
+        version: 5.0.2(rollup@3.29.4)
     devDependencies:
       '@solidjs/meta':
         specifier: ^0.29.3
@@ -661,7 +664,7 @@ importers:
         version: 0.13.1(solid-js@1.8.15)
       '@solidjs/start':
         specifier: ^1.0.0-rc.0
-        version: 1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
+        version: 1.0.0-rc.0(rollup@3.29.4)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
       '@tanstack/solid-query':
         specifier: ^5.29.3
         version: 5.29.3(solid-js@1.8.15)
@@ -671,9 +674,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.44.0
         version: 5.52.0(eslint@8.57.0)(typescript@4.9.5)
-      rimraf:
-        specifier: ^5.0.7
-        version: 5.0.7
       solid-js:
         specifier: ^1.8.15
         version: 1.8.15
@@ -682,7 +682,7 @@ importers:
         version: 6.5.0(postcss@8.4.38)(typescript@4.9.5)
       tsup-preset-solid:
         specifier: 0.1.8
-        version: 0.1.8(esbuild@0.15.18)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5))
+        version: 0.1.8(esbuild@0.21.5)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5))
       typescript:
         specifier: ^4.8.2
         version: 4.9.5
@@ -9813,13 +9813,13 @@ snapshots:
       rollup: 4.9.6
       tslib: 2.6.2
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.13.0)(tslib@2.6.2)(typescript@4.9.5)':
+  '@rollup/plugin-typescript@11.1.6(rollup@3.29.4)(tslib@2.6.2)(typescript@4.9.5)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       resolve: 1.22.8
       typescript: 4.9.5
     optionalDependencies:
-      rollup: 4.13.0
+      rollup: 3.29.4
       tslib: 2.6.2
 
   '@rollup/pluginutils@4.2.1':
@@ -9834,14 +9834,6 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 3.29.4
-
-  '@rollup/pluginutils@5.0.2(rollup@4.13.0)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.13.0
 
   '@rollup/pluginutils@5.1.0(rollup@3.29.4)':
     dependencies:
@@ -9970,6 +9962,32 @@ snapshots:
     dependencies:
       solid-js: 1.8.17
 
+  '@solidjs/start@1.0.0-rc.0(rollup@3.29.4)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      '@vinxi/server-components': 0.3.3(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      '@vinxi/server-functions': 0.3.2(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
+      defu: 6.1.4
+      error-stack-parser: 2.1.4
+      glob: 10.3.10
+      html-to-image: 1.11.11
+      radix3: 1.1.1
+      seroval: 1.0.4
+      seroval-plugins: 1.0.4(seroval@1.0.4)
+      shikiji: 0.9.19
+      source-map-js: 1.0.2
+      terracotta: 1.0.5(solid-js@1.8.15)
+      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
+      vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@testing-library/jest-dom'
+      - rollup
+      - solid-js
+      - supports-color
+      - vinxi
+      - vite
+
   '@solidjs/start@1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))':
     dependencies:
       '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
@@ -9987,32 +10005,6 @@ snapshots:
       terracotta: 1.0.5(solid-js@1.8.15)
       vite-plugin-inspect: 0.7.42(rollup@4.13.0)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))
       vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - rollup
-      - solid-js
-      - supports-color
-      - vinxi
-      - vite
-
-  '@solidjs/start@1.0.0-rc.0(rollup@4.13.0)(solid-js@1.8.15)(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))':
-    dependencies:
-      '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      '@vinxi/server-components': 0.3.3(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      '@vinxi/server-functions': 0.3.2(vinxi@0.3.10(@types/node@18.17.5)(ioredis@5.3.2)(terser@5.27.1))
-      defu: 6.1.4
-      error-stack-parser: 2.1.4
-      glob: 10.3.10
-      html-to-image: 1.11.11
-      radix3: 1.1.1
-      seroval: 1.0.4
-      seroval-plugins: 1.0.4(seroval@1.0.4)
-      shikiji: 0.9.19
-      source-map-js: 1.0.2
-      terracotta: 1.0.5(solid-js@1.8.15)
-      vite-plugin-inspect: 0.7.42(rollup@4.13.0)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
-      vite-plugin-solid: 2.9.1(solid-js@1.8.15)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@testing-library/jest-dom'
@@ -11825,12 +11817,12 @@ snapshots:
   esbuild-openbsd-64@0.15.18:
     optional: true
 
-  esbuild-plugin-solid@0.5.0(esbuild@0.15.18)(solid-js@1.8.15):
+  esbuild-plugin-solid@0.5.0(esbuild@0.21.5)(solid-js@1.8.15):
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-typescript': 7.23.3(@babel/core@7.20.12)
       babel-preset-solid: 1.8.16(@babel/core@7.20.12)
-      esbuild: 0.15.18
+      esbuild: 0.21.5
       solid-js: 1.8.15
     transitivePeerDependencies:
       - supports-color
@@ -15355,9 +15347,9 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup-preset-solid@0.1.8(esbuild@0.15.18)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5)):
+  tsup-preset-solid@0.1.8(esbuild@0.21.5)(solid-js@1.8.15)(tsup@6.5.0(postcss@8.4.38)(typescript@4.9.5)):
     dependencies:
-      esbuild-plugin-solid: 0.5.0(esbuild@0.15.18)(solid-js@1.8.15)
+      esbuild-plugin-solid: 0.5.0(esbuild@0.21.5)(solid-js@1.8.15)
       tsup: 6.5.0(postcss@8.4.38)(typescript@4.9.5)
       type-fest: 3.13.1
     transitivePeerDependencies:
@@ -15987,6 +15979,21 @@ snapshots:
       - supports-color
       - terser
 
+  vite-plugin-inspect@0.7.42(rollup@3.29.4)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1)):
+    dependencies:
+      '@antfu/utils': 0.7.7
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      debug: 4.3.4
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.3.1(@types/node@18.17.5)(terser@5.27.1)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   vite-plugin-inspect@0.7.42(rollup@4.13.0)(vite@5.1.6(@types/node@18.17.5)(terser@5.27.1)):
     dependencies:
       '@antfu/utils': 0.7.7
@@ -16013,21 +16020,6 @@ snapshots:
       picocolors: 1.0.0
       sirv: 2.0.4
       vite: 5.1.6(@types/node@20.11.26)(terser@5.27.1)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.7.42(rollup@4.13.0)(vite@5.3.1(@types/node@18.17.5)(terser@5.27.1)):
-    dependencies:
-      '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
-      debug: 4.3.4
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 5.3.1(@types/node@18.17.5)(terser@5.27.1)
     transitivePeerDependencies:
       - rollup
       - supports-color

--- a/turbo.json
+++ b/turbo.json
@@ -1,29 +1,33 @@
 {
-    "$schema": "https://turbo.build/schema.json",
-    "pipeline": {
-      "build": {
-        "dependsOn": ["^build"],
-        "outputs": ["dist/**", "build/**"]
-      },
-      "dev": {
-        "cache": false
-      },
-      "clean": {
-        "cache": false
-      },
-      "ts:check": {
-        "cache": false
-      },
-      "lint": {
-        "cache": false
-      },
-      "test": {
-        "cache": true,
-        "outputs": []
-      },
-      "test:coverage": {
-        "cache": false,
-        "outputs": []
-      }
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "build/**"
+      ]
+    },
+    "dev": {
+      "cache": false
+    },
+    "clean": {
+      "cache": false
+    },
+    "ts:check": {
+      "cache": false
+    },
+    "lint": {
+      "cache": false
+    },
+    "test": {
+      "cache": true
+    },
+    "test:coverage": {
+      "cache": false,
+      "outputs": []
     }
   }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -2,13 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**",
-        "build/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
     },
     "dev": {
       "cache": false


### PR DESCRIPTION
- Switch to `rimraf` for `rm -rf`
- Migrate to turbo v2