### PR TITLE
rename cache to query

### DIFF
--- a/.changeset/happy-kids-enjoy.md
+++ b/.changeset/happy-kids-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@solid-mediakit/auth-plugin": patch
+---
+
+rename cache to query

--- a/packages/auth/plugin/src/compiler/utils.ts
+++ b/packages/auth/plugin/src/compiler/utils.ts
@@ -33,7 +33,7 @@ export const addMissingImports = (
   opts: AuthPluginOptions,
   args: ReturnType<typeof getArgs>,
 ) => {
-  babelUtils.importIfNotThere(path, t, 'cache', '@solidjs/router')
+  babelUtils.importIfNotThere(path, t, 'query', '@solidjs/router')
   babelUtils.importIfNotThere(path, t, 'createAsync', '@solidjs/router')
   babelUtils.importIfNotThere(path, t, 'getRequestEvent', 'solid-js/web')
   babelUtils.importIfNotThere(path, t, 'getSession', '@solid-mediakit/auth')


### PR DESCRIPTION
the latest version of @solidjs/router renamed the `cache` function to `query`

closes #134 