### PR TITLE
[pRPC] Fix type inference issue with solid-query 5.71.4+ by using Accessor

### DIFF
--- a/packages/prpc/solid/src/types.ts
+++ b/packages/prpc/solid/src/types.ts
@@ -3,7 +3,6 @@ import {
   CancelOptions,
   CreateMutationResult,
   CreateQueryResult,
-  FunctionedParams,
   InvalidateOptions,
   InvalidateQueryFilters,
   Query,
@@ -87,7 +86,7 @@ export type DeepPartial<TObject> = TObject extends object
 export type GET$Options<
   Schema extends AllowedSchemas,
   Output,
-> = FunctionedParams<
+> = Accessor<
   Omit<
     SolidQueryOptions<
       Output,
@@ -105,7 +104,7 @@ export type Action$Options<
   Ctx,
   Schema extends AllowedSchemas,
   Output,
-> = FunctionedParams<
+> = Accessor<
   Omit<
     SolidMutationOptions<
       Output,


### PR DESCRIPTION
Since [solid-query 5.71.4](https://github.com/TanStack/query/releases/tag/v5.71.4) the usage of FunctionedParams is dropped in favor of Accessor. If prpc is used with solid-query 5.71.4+, type inference is broken. This pr fixes these problems.